### PR TITLE
feat: add command to toggle user admin state

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ You will get url that user has to visit in order to give us access to his Github
 "token": "BEARER TOKEN"
 ```
 
+### Admin user
+
+In order to access admin protected API endpoints you have to toggle your test user admin status.
+You can to so by updating database value for user. Or you can use `admin:toggle` artisan command that will be available in `local` mode
+
+You can run artisan command to toggle admin state for provided user:
+```bash
+  // on your local machine.
+  php artisan admin:toggle {username}
+
+  // Docker 🐳
+  sail artisan admin:toggle {username}
+```
+
 #### To authenticate requests, include an Authorization header with the value "Bearer {BEARER TOKEN}".
 
 ## Running Tests

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,10 +19,10 @@ class Kernel extends ConsoleKernel
     /**
      * Define the application's command schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
+     * @param Schedule $schedule
      * @return void
      */
-    protected function schedule(Schedule $schedule)
+    protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('inspire')->hourly();
     }
@@ -32,9 +32,17 @@ class Kernel extends ConsoleKernel
      *
      * @return void
      */
-    protected function commands()
+    protected function commands(): void
     {
-        $this->load(__DIR__.'/Commands');
+        $paths = [
+            __DIR__ . '/Commands'
+        ];
+
+        if ($this->app->environment('local')) {
+            $paths[] = __DIR__ . '/LocalCommands';
+        }
+
+        $this->load($paths);
 
         require base_path('routes/console.php');
     }

--- a/app/Console/LocalCommands/ToggleAdminState.php
+++ b/app/Console/LocalCommands/ToggleAdminState.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\LocalCommands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class ToggleAdminState extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'admin:toggle {username}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Toggle user admin role state';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $username = $this->argument('username');
+
+        $user = User::where('username', $username)->first();
+
+        if ($user) {
+            $user->forceFill([
+                'is_admin' => !$user->is_admin
+            ])->save();
+
+            $this->info("Admin state was toggled successfully for user '$username'!");
+            return;
+        }
+
+        $this->error("User with username '$username' does not exist!");
+    }
+}


### PR DESCRIPTION
- [x] Artisan command to toggle admin state
- [x] Updated readme to mention command

To toggle admin state for user run `php artisan admin:toggle {username}`. 

> ⚠️ Command will be available only for local development